### PR TITLE
Ticket #216: Proper floor division in CLI

### DIFF
--- a/lib/Shine/CLI/TextTable.py
+++ b/lib/Shine/CLI/TextTable.py
@@ -176,7 +176,7 @@ class TextTable(object):
         """Build a title string"""
         width = len(self._str_common(self._header).rstrip())
         title = " %s " % self.title
-        right = max((width - len(title)) / 2, 1)
+        right = max((width - len(title)) // 2, 1)
         left = max(width - len(title) - right, 1)
         if self.color:
             title = "%s%s%s" % (COLORS['header'], title, COLORS['stop'])


### PR DESCRIPTION
In Shine.CLI.Display, use proper floor division with // which is compatible with py2 and py3. We want a int here.

