### PR TITLE
Ticket #216: Write tempfiles in text mode

### DIFF
--- a/tests/Utils.py
+++ b/tests/Utils.py
@@ -59,7 +59,7 @@ def makeTempFilename():
 
 def makeTempFile(text):
     """ Create a temporary file with the provided text."""
-    tmp = tempfile.NamedTemporaryFile(prefix='shine-test-')
+    tmp = tempfile.NamedTemporaryFile(prefix='shine-test-', mode='w')
     tmp.write(text)
     tmp.flush()
     return tmp


### PR DESCRIPTION
When creating NamedTemporayFiles, open them in text mode instead of default binary mode.