### PR TITLE
Ticket #216: make Server class comparable

### DIFF
--- a/lib/Shine/Lustre/Server.py
+++ b/lib/Shine/Lustre/Server.py
@@ -93,6 +93,10 @@ class Server(object):
     def __str__(self):
         return "%s (%s)" % (self.hostname, ','.join(self.nids))
 
+    def __lt__(self, other):
+	# Cast hostname into str until NodeSet is sortable
+        return (str(self.hostname), self.nids) < (str(other.hostname), self.nids)
+
     @classmethod
     def hostname_long(cls):
         """


### PR DESCRIPTION
Fix "TypeError: '<' not supported between instances of 'Server' and 'Server'" class of error:
  File ".../Shine/Lustre/Component.py", line 424, in groupbyallservers
    sortlist = sorted(srvcomps, key=itemgetter(0))
TypeError: '<' not supported between instances of 'Server' and 'Server'